### PR TITLE
Don't try to connect to the server in __aenter__()

### DIFF
--- a/src/apolo_events_client/_client.py
+++ b/src/apolo_events_client/_client.py
@@ -76,7 +76,6 @@ class RawEventsClient:
         return self._ws
 
     async def __aenter__(self) -> Self:
-        await self._lazy_init()
         return self
 
     async def __aexit__(


### PR DESCRIPTION
It doesn't make sense in a real life, when multiple services are upgraded in the same time.
Early connection leads to early ConnectionError, nothing more